### PR TITLE
fix: remove unused import and fix type error

### DIFF
--- a/src/components/molecules/searchToggleInput.tsx
+++ b/src/components/molecules/searchToggleInput.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   forwardRef,
   useEffect,
   useImperativeHandle,


### PR DESCRIPTION
Removed unused React import in searchToggleInput.tsx to fix a linting error.

Closes #4